### PR TITLE
Fix buildapp to work with ASDF 2.27 as well as 2.26 and earlier.

### DIFF
--- a/buildapp.lisp
+++ b/buildapp.lisp
@@ -166,7 +166,7 @@ buildapp application."
     (defparameter *traversal-parents* nil)
 
     (defmethod asdf::traverse :around ((operation asdf:load-op)
-                                       (system asdf:system))
+                                       (system asdf:system) #+asdf2.27 &key)
       "Gather some relationship information about systems."
       (if *load-system*
           (progn


### PR DESCRIPTION
TRAVERSE was a private function in ASDF 2.26 and older.
2.27 makes it public, but after a change in signature. It now takes &key arguments.

Here's a patch to buildapp.
