### PR TITLE
replace the deprecated sb-ext:quit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ buildapp: command-line.lisp utils.lisp buildapp.lisp dumper.lisp package.lisp
 	  --eval "(require 'asdf)" \
 	  --eval "(require 'buildapp)" \
           --eval "(buildapp::build-buildapp)" \
-          --eval "(quit)"
+          --eval "(exit)"
 
 clean:
 	rm -f buildapp *~ *.fasl

--- a/buildapp.lisp
+++ b/buildapp.lisp
@@ -144,7 +144,7 @@ For the latest documentation, see http://www.xach.com/lisp/buildapp/
     (format *system-load-output* "~&Fatal ~A:~%  ~A~%"
             (type-of condition) condition)
     (print (sb-debug:backtrace-as-list) *logfile-output*)
-    (sb-ext:quit :unix-status 111)))
+    (sb-ext:exit :code 111)))
 
 (defun command-line-debugger (condition previous-hook)
   "The function to call if there are errors in the command-line
@@ -157,7 +157,7 @@ buildapp application."
       (terpri *error-output*)
       (write-string *short-usage* *error-output*)))
   (print (sb-debug:backtrace-as-list) *logfile-output*)
-  (sb-ext:quit :unix-status 1))
+  (sb-ext:exit :code 1))
 
 (dumpable asdf-ops
   (progn
@@ -390,7 +390,7 @@ it. If an exact filename is not found, file.lisp is also tried."
 ARGV. See *USAGE* for details."
   (when (string-equal (second argv) "--help")
     (write-string *usage* *standard-output*)
-    (sb-ext:quit))
+    (sb-ext:exit))
   (let* ((dumper (command-line-dumper (rest argv)))
          (*package* (find-package :buildapp))
          (dynamic-space-size (dynamic-space-size dumper)))

--- a/dumper.lisp
+++ b/dumper.lisp
@@ -120,7 +120,7 @@
                      (list
                       `(format *error-output* "Unknown dispatch name '~A', quitting~%"
                                binary-name)
-                      '(sb-ext:quit :unix-status 1))))))))))
+                      '(sb-ext:exit :code 1))))))))))
 
 (defgeneric entry-function-form (dumper)
   (:method (dumper)


### PR DESCRIPTION
SB-EXT:QUIT has been deprecated as of SBCL 1.0.56.55. I replaced it withSB-EXT:EXIT.
