### PR TITLE
Evaluate dumper-action-forms in CL-USER package.

### DIFF
--- a/buildapp.lisp
+++ b/buildapp.lisp
@@ -264,7 +264,8 @@ it. If an exact filename is not found, file.lisp is also tried."
 (defun dumper-action-form (dumper)
   (let ((forms (mapcar 'invoke-debugger-hook-wrapper
                        (dumper-action-forms dumper))))
-    `(progn ,@forms)))
+    `(let ((*package* (find-package "CL-USER")))
+       ,@forms)))
 
 (defun dumpfile-forms (dumper)
   "Return a list of forms to be saved to a dumpfile."

--- a/doc/index.html
+++ b/doc/index.html
@@ -445,10 +445,11 @@ For the latest documentation, see http://www.xach.com/lisp/buildapp/
   required <tt>:save-runtime-options</tt> argument?
 
 <li>The dumpfile performs the eval/load/load-system/require
-  actions. Each operation is evaluated with a fresh binding
-  of <tt>sb-ext:*invoke-debugger-hook*</tt> in sbcl
-  or <tt>ccl::*debugger-hook*</tt> in ccl to the buildapp debugger
-  function. If the binding is modified, the new value is saved.
+  actions. Each operation is evaluated in the <tt>cl-user</tt> package
+  and with a fresh binding of <tt>sb-ext:*invoke-debugger-hook*</tt>
+  in sbcl or <tt>ccl::*debugger-hook*</tt> in ccl to the buildapp
+  debugger function. If the binding is modified, the new value is
+  saved.
 
 <li>The dumpfile clears itself out of the environment:
 


### PR DESCRIPTION
Currently the dumper-action-forms are evaluated in the (gensym "DUMPER") package. This creates the possibility for missing package errors when load is executed later, both in the built image and in unrelated images. Here's a minimal example that triggers the undesirable behavior which this patch fixes:

```
buildapp \
    --eval "(load (compile-file \"test.lisp\"))" \
    --output ~/bin/irrelevant 

;;;; test.lisp

(print 'foo)

;;;;  load the fasl buildapp created from test.lisp into any image.
* (load "test")

debugger invoked on a SB-KERNEL:SIMPLE-PACKAGE-ERROR in thread
#<THREAD "main thread" RUNNING {1002AC3153}>:
  The name "DUMPER697" does not designate any package.
```
