### PR TITLE
Enable asdf directives even if --load-system is not used.

### DIFF
--- a/dumper.lisp
+++ b/dumper.lisp
@@ -90,7 +90,9 @@
 
 (defgeneric needs-asdf-p (dumper)
   (:method (dumper)
-    (find :load-system (actions dumper) :key 'first)))
+    (or
+     (find :load-system (actions dumper) :key 'first)
+     (asdf-directives dumper))))
 
 (defmethod print-object ((dumper dumper) stream)
   (print-unreadable-object (dumper stream :type t)


### PR DESCRIPTION
This allows the directives to be used even if asdf is invoked by other
means.
