### PR TITLE
By default compiles/install both sbcl and ccl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+buildapp-ccl
+buildapp-sbcl

--- a/buildapp
+++ b/buildapp
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Invoke the buildapp executable appropriate to the lisp specified in
+# the environment variable named "LISP."  If "LISP" is not set then
+# default to invoking buildapp-sbcl.
+#
+if [ "$LISP" == "ccl" ];then
+   exec $0-ccl $@
+else
+   exec $0-sbcl $@
+fi

--- a/doc/index.html
+++ b/doc/index.html
@@ -35,12 +35,15 @@ The latest version is 1.5.6, released on November 7th, 2015.
 
 <a name='installation'><h2>Installation</h2></a>
 
-<p>Buildapp does not require any libraries. To compile it with SBCL
-  you simply run <tt>make install</tt>. To compile with a different
-  lisp, just specify it after the make command:
-  <tt>make install LISP=&lt;my_favorite_lisp&gt;</tt>. For example,
-  you wanted to compile it under CCL you'd say
-  <tt>make install LISP=ccl</tt> By default, it is installed in
+<p>Buildapp does not require any libraries. To compile it you simply
+  run <tt>make install</tt>.  This will compile and install versions
+  of buildapp with whichever of SBCL and/or CCL are available on your
+  system.  To later call a particular version of buildapp either call
+  the specific executable (i.e., <tt>buildapp-sbcl</tt>
+  or <tt>buildapp-ccl</tt>) or call the <tt>buildapp</tt> executable
+  which will dispatch depending on the value of the <tt>LISP</tt>
+  environment variable (defaulting to SBCL).  By default, it is
+  installed in
   <tt>/usr/local/bin</tt>; to use another location,
   use <tt>make&nbsp;DESTDIR=/path&nbsp;install</tt>.
 


### PR DESCRIPTION
Only tries to install versions for which the required lisp is found in
the user's path.  Different executables are compiled to buildapp-sbcl
and buildapp-ccl respectively.  The buildapp file is a short shell
script which dispatches to the appropriate buildapp version depending on
the value of the LISP environment variable (defaulting to SBCL).

See the diff of doc/index.html for additional information.