### PR TITLE
New --core command line flag passed down to the invocation of SBCL.

### DIFF
--- a/buildapp.lisp
+++ b/buildapp.lisp
@@ -127,6 +127,10 @@ Other flags:"
 "
   --sbcl PATH-TO-SBCL       Use PATH-TO-SBCL instead of the sbcl program
                               found in your PATH environment variable"
+#+sbcl
+"
+  --core PATH-TO-CORE       Use PATH-TO-CORE instead of the standard core
+                              as chosen by your sbcl installation"
 #+ccl
 "
   --ccl PATH-TO-CCL         Use PATH-TO-CCL instead of the ccl program
@@ -391,6 +395,7 @@ ARGV. See *USAGE* for details."
     (quit))
   (let* ((dumper (command-line-dumper (rest argv)))
          (*package* (find-package :buildapp))
+         (core-file (core-file dumper))
          #+sbcl (dynamic-space-size (dynamic-space-size dumper)))
     (with-tempfile (stream ("dumper.lisp" file))
       (write-dumpfile dumper stream)
@@ -401,6 +406,11 @@ ARGV. See *USAGE* for details."
                                   #+ccl  (ccl  dumper)
                                   (flatten
                                    (list
+                                    #+sbcl
+                                    (when core-file
+                                      (list "--core"
+                                            (native-namestring
+                                             core-file)))
                                     #+sbcl
                                     (when dynamic-space-size
                                       (list "--dynamic-space-size"

--- a/command-line.lisp
+++ b/command-line.lisp
@@ -139,6 +139,8 @@
           (:sbcl
            (when (sbcl plan)
              (setf (sbcl plan) value)))
+          (:core
+           (setf (core-file plan) value))
           (:ccl
            (when (ccl plan)
              (setf (ccl plan) value)))

--- a/dumper.lisp
+++ b/dumper.lisp
@@ -59,6 +59,10 @@
     :initarg :sbcl
     :accessor sbcl
     :initform "sbcl")
+   (core-file
+    :initarg :core-file
+    :accessor core-file
+    :initform nil)
    (ccl
     :initarg :ccl
     :accessor ccl


### PR DESCRIPTION
To facilitate the use of a non-standard core file, and also to allow
buildapp be easily used with non-global sbcl installations (without
having to resort to environmental variables.)