### PR TITLE
Ensure physical-pathname.

### DIFF
--- a/buildapp.lisp
+++ b/buildapp.lisp
@@ -424,7 +424,8 @@ ARGV. See *USAGE* for details."
     (main (list "sbcl"
                 "--asdf-path"
                 (native-namestring
-                 (asdf:system-relative-pathname :buildapp "./"))
+                 (translate-logical-pathname
+                  (asdf:system-relative-pathname :buildapp "./")))
                 "--load-system" "buildapp"
                 "--entry" "buildapp:main"
                 "--output"


### PR DESCRIPTION
Fix call to NATIVE-NAMESTRING on return of ASDF:SYSTEM-RELATIVE-PATHNAME, which may return a logical pathname.