### PR TITLE
Test that buildapp does not see `--dynamic-space-size`

### DIFF
--- a/command-line.lisp
+++ b/command-line.lisp
@@ -109,6 +109,7 @@
         (unless (output plan)
           (error 'missing-output-argument))
         (setf (asdf-directives plan) (reverse (asdf-directives plan)))
+        (describe plan)
         (return plan))
       (let* ((argument (pop args))
              (value (pop args))
@@ -162,7 +163,3 @@
            (setf (dynamic-space-size plan) (parse-integer value)))
           (t
            (error 'unknown-argument :flag argument)))))))
-
-
-
-

--- a/tests/runtime-args-test.sh
+++ b/tests/runtime-args-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+THIS_DIR=$(realpath $(dirname ${BASH_SOURCE}))
+BUILDAPP=${BUILDAPP:-buildapp}
+
+
+${BUILDAPP} --output test-app --dynamic-space-size 100000 --asdf-path ${THIS_DIR}/ --load-system test-system --entry 'cl-user::main' --dumpfile-copy ./dumpfile.lisp
+

--- a/tests/src.lisp
+++ b/tests/src.lisp
@@ -1,0 +1,6 @@
+(in-package :cl-user)
+
+(defun main (argv)
+  (declare (ignore argv))
+  (format t "~&This is the test application~%")
+  (uiop:quit 0))

--- a/tests/test-system.asd
+++ b/tests/test-system.asd
@@ -1,0 +1,2 @@
+(defsystem test-system
+  :components ((:file "src")))


### PR DESCRIPTION
Running the `tests/runtime-args-test.sh` on this branch (after `make`) as

    cd tests
    BUILDAPP=../buildapp ./runtime-args-test.sh

will `describe` the `dumper` object after parsing the command line, demonstrating that the `dynamic-space-size` slot is unset.

This branch should not be merged, but checking it out and running the test will demonstrate #36 which is the rationale for #39 